### PR TITLE
Set QML module's import in specific var

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,17 +1,38 @@
 'use strict';
 
+function makePathRelative(p) {
+  var delimiter = p[0];
+
+  // Remove delimiters
+  p = p.slice(1, -1);
+
+  // Add ./ if necessary
+  if (p[0] !== '.') {
+    p = `./${p}`;
+  }
+
+  return `${delimiter}${p}${delimiter}`;
+}
+
 module.exports.processors = {
   ".js": {
-    preprocess: function(text, filename) {
-      // Ignore QML head lines and transform JS import in CommonJS require
-      text = text
-        .replace(/^\.import (['"])([^'"]+\.js)(['"]) as (.+)$/mg, 'var $4 = require($1./$2$3);')
-        .replace(/^\.(pragma|import).*$/mg, '\/* Ignored QML */');
+    preprocess: function(text) {
+      text = text.replace(/^\.import .+$/gm, function (line) {
+        var parts = line.split(' ');
+
+        // Importing QML modules implies having 5 elements
+        if (parts.length < 5) {
+          return `var ${parts[3]} = require(${makePathRelative(parts[1])});`;
+        }
+
+        return `var ${parts[4]} = {};`;
+      })
+
+      text = text.replace(/^\.pragma.*$/gm, '// Ignored QML');
 
       return [text];
     },
-
-    postprocess: function(messages, filename) {
+    postprocess: function(messages) {
       // Do nothing
       return messages[0];
     }


### PR DESCRIPTION
Before...

```js
.import my.module 1.0 as MyModule
```

...was transformed to:

```js
/* Ignored QML */
```

Now it's transformed to:

```js
var MyModule = {};
```

So EsLint doesn't throw undeclared errors.